### PR TITLE
Updated handle_set_brightness_intent to pass 'value' to dialog

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -388,7 +388,7 @@ class PhillipsHueSkill(MycroftSkill):
         group.brightness = brightness
         group.on = True
         if self.verbose:
-            self.speak_dialog('set.brightness', {'brightness': brightness})
+            self.speak_dialog('set.brightness', {'brightness': value})
 
     @intent_handler
     def handle_adjust_color_temperature_intent(self, message, group):


### PR DESCRIPTION
Currently, if you tell mycroft 'set bedroom light to 100%', one of the possible responses is 'setting the brightness to 254 percent', this pull request fixes that bug and will make it 'setting the brightness to 100 percent'