### PR TITLE
Set brightness after setting group to on

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -385,8 +385,8 @@ class PhillipsHueSkill(MycroftSkill):
     def handle_set_brightness_intent(self, message, group):
         value = int(message.data['Value'].rstrip('%'))
         brightness = int(value / 100.0 * 254)
-        group.brightness = brightness
         group.on = True
+        group.brightness = brightness
         if self.verbose:
             self.speak_dialog('set.brightness', {'brightness': value})
 


### PR DESCRIPTION
Currently if a light is off (and was previously at 100%) and you say "set the light to 10%", mycroft will turn the light on, but it'll come on at the previous value (100%).

I've swapped the order of group.brightness and group.on so that now the light will come on at the desired brightness level