### PR TITLE
Update OnKeyword.voc

### DIFF
--- a/vocab/de-de/OnKeyword.voc
+++ b/vocab/de-de/OnKeyword.voc
@@ -1,3 +1,4 @@
 ein
 on
 einschalten
+an


### PR DESCRIPTION
"an" is used more often than "ein" for lights in German. Both are used though. The meaning is the same.